### PR TITLE
tests now can run in browser or in node

### DIFF
--- a/myEach.html
+++ b/myEach.html
@@ -1,0 +1,26 @@
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Mocha Tests</title>
+  <link href="node_modules/mocha/mocha.css" rel="stylesheet" />
+</head>
+<body>
+  <div class='container'>
+    <div id="mocha"></div>
+    <script src="https://cdn.rawgit.com/jquery/jquery/2.1.4/dist/jquery.min.js"></script>
+    <script src="node_modules/mocha/mocha.js"></script>
+    <script src="node_modules/chai/chai.js"></script>
+    <script src="node_modules/chai-spies/chai-spies.js"></script>
+
+    <script src="myEach.js"></script>
+    <script>mocha.setup('bdd')</script>
+
+    <script src="test/test-myEach.js"></script>
+    <script>
+      //mocha.checkLeaks();
+      mocha.globals(['jQuery']);
+      mocha.run();
+    </script>
+  </div>
+</body>
+</html>

--- a/myEach.js
+++ b/myEach.js
@@ -17,6 +17,8 @@ function myEach(arr, callback) {
 
 
 
-
-// export this function (you can ignore this for now)
-module.exports = myEach;
+/* used only in CommonJS environments (e.g. node) */
+if (typeof exports !== 'undefined' && this.exports !== exports) {
+  // export this function (STUDENTS: you may ignore this for now)
+  module.exports = myEach;
+}

--- a/solutions/myEach.js
+++ b/solutions/myEach.js
@@ -17,6 +17,8 @@ function myEach(arr, callback) {
 
 
 
-
-// export this function (you can ignore this for now)
-module.exports = myEach;
+/* used only in CommonJS environments (e.g. node), skip in browser */
+if (typeof exports !== 'undefined' && this.exports !== exports) {
+  // export this function (STUDENTS: you may ignore this for now)
+  module.exports = myEach;
+}

--- a/test/test-myEach.js
+++ b/test/test-myEach.js
@@ -3,16 +3,18 @@
  * To run these tests do `mocha spec/test-myEach.js`
 */
 
-var mocha = require('mocha');
-var chai = require('chai');
-var spies = require('chai-spies');
-chai.use(spies);
+/* used only in CommonJS environments (e.g. node), skip in browser */
+if (typeof exports !== 'undefined' && this.exports !== exports) {
+  var mocha = require('mocha');
+  var chai = require('chai');
+  var spies = require('chai-spies');
+  var myEach = require('../myEach');
+  chai.use(spies);
+}
 
 var expect = chai.expect;
 chai.config.includeStack = false; // turn off stack trace
 chai.config.showDiff = true; // turn on reporter diff display
-
-var myEach = require('../myEach');
 
 describe('myEach', function() {
   // sample data


### PR DESCRIPTION
This relies on environment sniffing to determine if it's running in node or in the browser.  That's ugly and certainly not dry.  I considered other alternatives like browserify (would require students to "build" after every change), requireJS (more difficult for students) and eventually decided that the trade-off was just going to have to be (not DRY + comment to clarify).

Also, yes I'm sure `typeof exports !== 'undefined' && this.exports !== exports` isn't the best test in the world and could fail in some environment; but it's still overkill for what we're doing.  
